### PR TITLE
Fix inline image validation

### DIFF
--- a/src/lib/actions/inlineImage.ts
+++ b/src/lib/actions/inlineImage.ts
@@ -12,8 +12,13 @@ export type Opts = {
 
 const defaultOpts: Opts = {
   extPattern: /(jpe?g|png|gif|webp)$/,
-  validate: (value: string, extPattern: RegExp) =>
-    new URL(value.toLowerCase()).pathname.match(extPattern) !== null,
+  validate: (value: string, extPattern: RegExp) => {
+    try {
+      return new URL(value.toLowerCase()).pathname.match(extPattern) !== null;
+    } catch {
+      return false;
+    }
+  },
   attributes: {},
   tagName: 'img',
   className: '',


### PR DESCRIPTION
Failed parse url when `value` is including Japanese characters (i.e. `"nstr.jpを取ろうかと思ったけどmstdn.jp"`);